### PR TITLE
Add dependencies missing from the requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 tweepy==3.8.0
 pillow==8.3.2
 dropbox
+numpy
+dotenv


### PR DESCRIPTION
The `image_getter.py` module is importing unspecified build dependencies. This PR should resolve that issue. #hacktoberfest